### PR TITLE
fix: bump core to 1.2.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,7 @@ lazy val tests = project
 lazy val dependencies =
   new {
     val scalatest = "org.scalatest"  %% "scalatest" % "3.2.18" % Test
-    val core      = "de.dnpm.dip"    %% "core"      % "1.1.1"
+    val core      = "de.dnpm.dip"    %% "core"      % "1.2.1"
   }
 
 

--- a/catalogs_packaged/src/main/scala/de/dnpm/dip/atc/catalogs/Loader.scala
+++ b/catalogs_packaged/src/main/scala/de/dnpm/dip/atc/catalogs/Loader.scala
@@ -1,7 +1,7 @@
 package de.dnpm.dip.atc.catalogs
 
 
-import java.io.InputStream
+import cats.Eval
 import cats.data.NonEmptyList
 import de.dnpm.dip.atc.impl.ATCCatalogsImpl
 
@@ -22,9 +22,18 @@ class ClassPathLoader extends ATCCatalogsImpl.Loader
       (2020 to 2025).map(_.toString).toList
     )
 
-  override def inputStreams: NonEmptyList[(String,InputStream)] = 
+/*
+  override def inputStreams: NonEmptyList[(String,Eval[InputStream])] = 
     versions.map( v =>
-      v -> this.getClass.getClassLoader.getResourceAsStream(s"ATC_$v.csv")
+      v -> Eval.later(this.getClass.getClassLoader.getResourceAsStream(s"ATC_$v.csv"))
+    )
+*/ 
+
+  override def catalogs = //: NonEmptyList[(String,Eval[CodeSystem[ATC]])] = 
+    versions.map(
+      v => v -> Eval.later(
+        ATCCatalogsImpl.TsvParser.parse(v,this.getClass.getClassLoader.getResourceAsStream(s"ATC_$v.csv"))
+      )
     )
   
 }

--- a/catalogs_packaged/src/main/scala/de/dnpm/dip/atc/catalogs/Loader.scala
+++ b/catalogs_packaged/src/main/scala/de/dnpm/dip/atc/catalogs/Loader.scala
@@ -3,6 +3,8 @@ package de.dnpm.dip.atc.catalogs
 
 import cats.Eval
 import cats.data.NonEmptyList
+import de.dnpm.dip.coding.CodeSystem
+import de.dnpm.dip.coding.atc.ATC
 import de.dnpm.dip.atc.impl.ATCCatalogsImpl
 
 
@@ -22,18 +24,13 @@ class ClassPathLoader extends ATCCatalogsImpl.Loader
       (2020 to 2025).map(_.toString).toList
     )
 
-/*
-  override def inputStreams: NonEmptyList[(String,Eval[InputStream])] = 
-    versions.map( v =>
-      v -> Eval.later(this.getClass.getClassLoader.getResourceAsStream(s"ATC_$v.csv"))
-    )
-*/ 
-
-  override def catalogs = //: NonEmptyList[(String,Eval[CodeSystem[ATC]])] = 
+  override def catalogs: NonEmptyList[(String,Eval[CodeSystem[ATC]])] =
     versions.map(
-      v => v -> Eval.later(
-        ATCCatalogsImpl.TsvParser.parse(v,this.getClass.getClassLoader.getResourceAsStream(s"ATC_$v.csv"))
-      )
+      version => version -> Eval.later {
+        val stream = this.getClass.getClassLoader.getResourceAsStream(s"ATC_$version.csv")
+        require(stream != null, s"Classpath resource ATC_$version.csv not found")
+        ATCCatalogsImpl.TsvParser.parse(version, stream)
+      }
     )
   
 }

--- a/impl/src/main/scala/de/dnpm/dip/atc/impl/ATCCatalogsImpl.scala
+++ b/impl/src/main/scala/de/dnpm/dip/atc/impl/ATCCatalogsImpl.scala
@@ -1,11 +1,7 @@
 package de.dnpm.dip.atc.impl
 
 
-import java.io.{
-  InputStream,
-  File,
-  FileInputStream
-}
+import java.io.InputStream
 import scala.util.Try
 import cats.{
   Applicative,
@@ -17,7 +13,6 @@ import scala.collection.concurrent.{
   TrieMap
 }
 import de.dnpm.dip.util.{
-  Logging,
   SPI,
   SPILoader
 }
@@ -61,22 +56,22 @@ object ATCCatalogsImpl
   //---------------------------------------------------------------------------
   trait Loader
   {
-    def inputStreams: NonEmptyList[(String,InputStream)]
+    def catalogs: NonEmptyList[(String,Eval[CodeSystem[ATC]])]
   }
 
   trait LoaderSPI extends SPI[Loader]
 
   private object Loader extends SPILoader[LoaderSPI]
 
-
+/*
   private class DefaultLoader extends Loader with Logging
   {
     val sysProp = "dnpm.dip.catalogs.dir"
 
     val fileName = """ATC_(\d{4})\.csv""".r
        
-    override def inputStreams: NonEmptyList[(String,InputStream)] = {
-
+    override def inputStreams: NonEmptyList[(String,Eval[InputStream])] = {
+      ???
       Option(System.getProperty(sysProp)).map(new File(_)) match {
 
         case None => {
@@ -92,18 +87,17 @@ object ATCCatalogsImpl
               .toList
               .map(f =>
                 f.getName match {
-                  case fileName(year) => (year, new FileInputStream(f)) 
+                  case fileName(year) => (year, Eval.later(new FileInputStream(f))) 
                 } 
               )
           )
 
       }
-
     }
   }
+*/
   //---------------------------------------------------------------------------
   //---------------------------------------------------------------------------
-
 
   object TsvParser
   {
@@ -195,17 +189,13 @@ object ATCCatalogsImpl
   }
 
   private val loader =
-    Loader.getInstance.getOrElse(new DefaultLoader)
+    Loader.getInstance.get//OrElse(new DefaultLoader)
 
 
 
   private val catalogs: Map[String,Eval[CodeSystem[ATC]]] =
     TrieMap.from( 
-      loader.inputStreams
-        .toList
-        .map {
-          case (version,in) => version -> Eval.later { TsvParser.parse(version,in) }
-        }
+      loader.catalogs.toList
     )
 
 


### PR DESCRIPTION
fix: Added lazy-loading of ATC catalogs for better resource efficiency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated core library dependency to version 1.2.1

* **Refactor**
  * Catalog provisioning moved from eager stream-based loading to lazy, deferred evaluation of versioned catalogs
  * Public loader interface updated to expose versioned catalogs; lookups now return evaluated catalog instances on demand
<!-- end of auto-generated comment: release notes by coderabbit.ai -->